### PR TITLE
feat: Add NewOnBehalfOfClient for user-scoped auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ if err != nil {
 fmt.Println("declared Incident", createIncidentResp.Incident.IncidentID)
 ```
 
+## On-behalf-of authentication
+
+If you need to make API calls on behalf of a specific Grafana user (rather than
+as a service account), use `NewOnBehalfOfClient` with the user's access token
+and ID token:
+
+```go
+client := incident.NewOnBehalfOfClient(
+	"https://your-stack.grafana.net/api/plugins/grafana-irm-app/resources/api/v1",
+	accessToken,
+	idToken,
+)
+incidentsService := incident.NewIncidentsService(client)
+```
+
 ## Handle webhooks from Grafana Incident
 
 You can use the [Outgoing Webhook integration](https://grafana.com/docs/grafana-cloud/incident/integrations/configure-outgoing-webhooks/) to get Grafana Incident to POST a request on specific events.

--- a/client.go
+++ b/client.go
@@ -1,0 +1,31 @@
+package incident
+
+import (
+	"net/http"
+	"time"
+)
+
+// NewOnBehalfOfClient makes a new Client that authenticates on behalf of
+// a specific Grafana user using their access token and ID token.
+//
+// This is used when a service needs to make API calls as a specific user,
+// rather than as a service account. The accessToken is set as the
+// X-Access-Token header and the idToken is set as the X-Grafana-Id header
+// on every request.
+//
+// The remoteHost should be
+// "https://your-stack.grafana.net/api/plugins/grafana-irm-app/resources/api/v1"
+// with `your-stack.grafana.net` pointing to your instance.
+func NewOnBehalfOfClient(remoteHost, accessToken, idToken string) *Client {
+	c := &Client{
+		RemoteHost: remoteHost,
+		Debug:      func(s string) { /* no-op by default */ },
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		BeforeRequest: func(r *http.Request) error {
+			r.Header.Set("X-Access-Token", accessToken)
+			r.Header.Set("X-Grafana-Id", idToken)
+			return nil
+		},
+	}
+	return c
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,34 @@
+package incident
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestNewOnBehalfOfClient(t *testing.T) {
+	is := is.New(t)
+
+	remoteHost := "https://test-stack.grafana.net/api/plugins/grafana-irm-app/resources/api/v1"
+	accessToken := "test-access-token"
+	idToken := "test-id-token"
+
+	client := NewOnBehalfOfClient(remoteHost, accessToken, idToken)
+
+	is.Equal(client.RemoteHost, remoteHost) // RemoteHost should be set
+	is.True(client.HTTPClient != nil)       // HTTPClient should not be nil
+	is.True(client.BeforeRequest != nil)    // BeforeRequest should not be nil
+	is.True(client.Debug != nil)            // Debug should not be nil
+
+	// Verify BeforeRequest sets the correct headers.
+	req, err := http.NewRequest(http.MethodPost, "https://example.com", nil)
+	is.NoErr(err)
+
+	err = client.BeforeRequest(req)
+	is.NoErr(err)
+
+	is.Equal(req.Header.Get("X-Access-Token"), accessToken) // X-Access-Token header
+	is.Equal(req.Header.Get("X-Grafana-Id"), idToken)       // X-Grafana-Id header
+	is.Equal(req.Header.Get("Authorization"), "")            // Authorization should not be set
+}


### PR DESCRIPTION
## Summary
- Adds `NewOnBehalfOfClient(remoteHost, accessToken, idToken)` constructor that authenticates using `X-Access-Token` and `X-Grafana-Id` headers for on-behalf-of auth
- Enables callers to make API calls as a specific Grafana user rather than as a service account
- Adds tests and README documentation for the new constructor

## Test plan
- [x] `TestNewOnBehalfOfClient` verifies correct header injection (`X-Access-Token`, `X-Grafana-Id`) and no `Authorization` header leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)