### PR TITLE
ci: add CI workflow, CODEOWNERS, and harden test setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/grafana-irm-backend

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: stable
+          check-latest: true
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code
+      - name: Vet
+        run: go vet ./...
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.24", "1.25", "1.26"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+      - name: Test
+        run: go test -race -count=1 ./...

--- a/incident_examples_test.go
+++ b/incident_examples_test.go
@@ -8,11 +8,11 @@ import (
 	incident "github.com/grafana/incident-go"
 )
 
-// ExampleCreateIncident shows how to create an incident.
+// ExampleIncidentsService_CreateIncident shows how to create an incident.
 // It uses the incident.NewTestClient so all responses are stubbed,
 // you should use incident.NewClient, specifying the API endpoint
 // and the service account token to send with the requests.
-func ExampleCreateIncident() {
+func ExampleIncidentsService_CreateIncident() {
 	ctx := context.Background()
 	client := incident.NewTestClient()
 	incidentsService := incident.NewIncidentsService(client)

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,4 +1,4 @@
-package incident
+package incident_test
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	incident "github.com/grafana/incident-go"
 	"github.com/matryer/is"
 )
 
@@ -20,13 +21,13 @@ func TestVerifySignature(t *testing.T) {
 	goodRequest, err := http.NewRequest(method, url, strings.NewReader(testPayload))
 	is.NoErr(err)
 	goodRequest.Header.Set("gi-signature", "t=1678360185,v1=66ed620915831e9ab71604bf35d9b7cf2e71978ed6e62be6fd0e5194289849c7")
-	err = VerifySignature(goodRequest, secret) // valid gi-signature
+	err = incident.VerifySignature(goodRequest, secret) // valid gi-signature
 	is.NoErr(err)
 
 	badRequest, err := http.NewRequest(method, url, strings.NewReader(testPayload))
 	is.NoErr(err)
 	badRequest.Header.Set("gi-signature", "t=123456,v1=some-bad-signature")
-	err = VerifySignature(badRequest, secret)
+	err = incident.VerifySignature(badRequest, secret)
 	is.Equal(err, errors.New("invalid GI-Signature")) // invalid gi-signature
 }
 
@@ -40,11 +41,11 @@ func TestParseWebhook(t *testing.T) {
 
 	request, err := http.NewRequest("POST", testURL, strings.NewReader(testPayload))
 	is.NoErr(err)
-	bodyHash := Hash([]byte(testPayload))
+	bodyHash := incident.Hash([]byte(testPayload))
 	stringToSign := bodyHash + ":" + unixTime + ":v1"
-	signature := GenerateSignature([]byte(stringToSign), testSecret)
+	signature := incident.GenerateSignature([]byte(stringToSign), testSecret)
 	request.Header.Set("GI-Signature", fmt.Sprintf("t=%s,v1=%s", unixTime, signature))
-	parsed, err := ParseWebhook(request, testSecret)
+	parsed, err := incident.ParseWebhook(request, testSecret)
 	is.NoErr(err)
 	is.Equal(parsed.ID, "webhook-out-6409be79a7ee628da2a70dbe") // parsed.ID
 }


### PR DESCRIPTION
## What?
A few repo-hygiene changes bundled together:

- New `.github/workflows/ci.yml` that vets, checks `go mod tidy`, and runs `go test -race` against a Go matrix (1.24, 1.25, 1.26). Actions are pinned to commit SHAs with `persist-credentials: false`.
- `.github/CODEOWNERS` making `@grafana/grafana-irm-backend` own the repo.
- Dependabot gets a 7-day `cooldown` so it won't jump on brand-new releases.
- Test cleanup: renamed `ExampleCreateIncident` to `ExampleIncidentsService_CreateIncident` (the old name pointed at a non-existent package-level identifier and broke the build), and moved `webhook_test.go` to `package incident_test` so the suite exercises the public API.

## Why?
There was no CI here, so nothing caught the fact that the package didn't even compile under test — the bad example name was failing the whole `go test` build. Fixing that and adding CI means it won't regress silently.

The CODEOWNERS and Dependabot cooldown are straightforward supply-chain/ownership hygiene, and pinning actions by SHA plus dropping persisted credentials closes the zizmor findings.

## How can I test it?
1. `go test -race ./...` locally — should pass and the suite now runs as `incident_test`.
2. Open the PR and confirm the CI matrix (1.24/1.25/1.26) and the `check` job go green.